### PR TITLE
remove unnecessary variable

### DIFF
--- a/algorithms/next_permutation.py
+++ b/algorithms/next_permutation.py
@@ -4,8 +4,7 @@ def next_permutation(nums):
         l -= 1
     if l == 0:
         # if it doesn't exist, return smallest
-        nums = nums[::-1]
-        return nums
+        return nums[::-1]
     while nums[r] <= nums[l-1]:
         r -= 1
     # swap and reverse suffix elements


### PR DESCRIPTION
BTW, I prefer to use nums[i] instead of nums[i-1],  e.g.  [while nums[r] <= nums[l-1]:](https://github.com/necusjz/awesome-cs/blob/4d1f320292abe1a7af84caf6897066e287fcc02f/algorithms/next_permutation.py#L9), I could forget to -1.
Here is another solution. FYI.


```python
class Solution:
    def nextPermutation(self, nums: List[int]) -> None:
        i = len(nums) - 2
        while i >= 0 and nums[i] >= nums[i + 1]:
            i -= 1
        if i >= 0:
            j = len(nums) - 1
            while j >= 0 and nums[i] >= nums[j]:
                j -= 1
            nums[i], nums[j] = nums[j], nums[i]
            
        i, j = i + 1, len(nums) - 1
        while i < j:
            nums[i], nums[j] = nums[j], nums[i]
            i += 1
            j -= 1
```
            